### PR TITLE
Added basic spread test definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ cmd/VERSION
 /pebble
 
 dist/
+
+# Spread temp files
+.spread-reuse.*

--- a/spread-tests/install-go.sh
+++ b/spread-tests/install-go.sh
@@ -1,0 +1,6 @@
+#! /usr/bin/env bash
+
+set -e
+
+apt-get update
+apt-get install golang -y

--- a/spread-tests/install-go.sh
+++ b/spread-tests/install-go.sh
@@ -1,6 +1,0 @@
-#! /usr/bin/env bash
-
-set -e
-
-apt-get update
-apt-get install golang -y

--- a/spread-tests/install_gcc.sh
+++ b/spread-tests/install_gcc.sh
@@ -1,0 +1,12 @@
+#! /usr/bin/env bash
+
+# Installs gcc as a deb
+#
+# This is required because gcc is one of the dependencies of the test
+# framework.
+
+set -e
+
+apt-get update
+apt-get install gcc -y
+

--- a/spread-tests/install_go.sh
+++ b/spread-tests/install_go.sh
@@ -1,0 +1,16 @@
+#! /usr/bin/env bash
+
+# This script installs the version of Go required by the go.mod file, as a
+# snap.
+
+set -e
+
+GO_MOD="${SPREAD_PATH}/go.mod"
+VERSION_PATTERN="[[:digit:]]+\.[[:digit:]]+"
+
+GO_VERSION=$(cat "${GO_MOD}" \
+    | grep -Ex "go\s+${VERSION_PATTERN}" \
+    | grep -E --only-matching "${VERSION_PATTERN}")
+
+snap wait system seed.loaded
+snap install go --classic --channel=${GO_VERSION}

--- a/spread-tests/integration/default_layers/001-base-layer.yaml
+++ b/spread-tests/integration/default_layers/001-base-layer.yaml
@@ -1,0 +1,8 @@
+services:
+    dummy:
+        override: replace
+        summary: Dummy service
+        command: ../dummy_service.sh
+        startup: enabled
+        on-failure: shutdown
+

--- a/spread-tests/integration/dummy_service.sh
+++ b/spread-tests/integration/dummy_service.sh
@@ -1,0 +1,13 @@
+#! /usr/bin/env bash
+
+set -e
+
+touch "${TASK_DIR}/dummy_service_started.tok"
+
+while true
+do
+    echo "This is a dummy service log"
+    sleep 2
+done
+
+

--- a/spread-tests/integration/pebble_wrapper.sh
+++ b/spread-tests/integration/pebble_wrapper.sh
@@ -1,0 +1,13 @@
+#! /usr/bin/env bash
+
+# This script wraps the command and setup needed to run pebble from source
+
+set -e
+
+export PEBBLE="${TASK_DIR}"
+SRC="${SPREAD_PATH}/cmd/pebble"
+
+echo "Running command \"go run $SRC $@\""
+
+go run $SRC $@
+

--- a/spread-tests/integration/start_pebble.sh
+++ b/spread-tests/integration/start_pebble.sh
@@ -1,0 +1,17 @@
+#! /usr/bin/env bash
+
+set -e
+
+"${SUITE_DIR}/pebble_wrapper.sh" run &> /dev/null &
+disown $!
+
+# Spin on this file to ensure the dummy service has been started
+until [ -e "${TASK_DIR}/dummy_service_started.tok" ]
+do
+    echo "Waiting for dummy_service_started.tok to exist"
+    sleep 1
+done
+
+echo "Found dummy_service_started.tok, preparation finished"
+sleep 1
+

--- a/spread-tests/integration/stop_pebble.sh
+++ b/spread-tests/integration/stop_pebble.sh
@@ -1,0 +1,16 @@
+#! /usr/bin/env bash
+
+set -e
+
+declare PEBBLE_PID=$(pgrep -x pebble)
+
+if [ -n "$PEBBLE_PID" ]; then
+    echo "Killing pebble"
+    kill -s TERM $PEBBLE_PID
+fi
+
+rm -f \
+    "${TASK_DIR}/.pebble.socket" \
+    "${TASK_DIR}/.pebble.state" \
+    "${TASK_DIR}/.pebble.socket.untrusted" \
+    "${TASK_DIR}/dummy_service_started.tok"

--- a/spread-tests/integration/task_autostart/layers
+++ b/spread-tests/integration/task_autostart/layers
@@ -1,0 +1,1 @@
+../default_layers

--- a/spread-tests/integration/task_autostart/task.yaml
+++ b/spread-tests/integration/task_autostart/task.yaml
@@ -1,0 +1,11 @@
+
+summary: Dummy service autostart test
+kill-timeout: 2m
+
+execute: |
+    ${SUITE_DIR}/pebble_wrapper.sh logs | grep -e "dummy service log"
+    ${SUITE_DIR}/pebble_wrapper.sh checks 2>&1 | grep -e "Plan has no health checks"
+    ${SUITE_DIR}/pebble_wrapper.sh warnings | grep -e "No warnings"
+    ${SUITE_DIR}/pebble_wrapper.sh services | grep -E -e "dummy\s+enabled\s+active"
+    ${SUITE_DIR}/pebble_wrapper.sh changes | grep -E -e "Autostart service \"dummy\""
+

--- a/spread-tests/integration/task_manualstart/layers
+++ b/spread-tests/integration/task_manualstart/layers
@@ -1,0 +1,1 @@
+../default_layers

--- a/spread-tests/integration/task_manualstart/task.yaml
+++ b/spread-tests/integration/task_manualstart/task.yaml
@@ -1,0 +1,11 @@
+
+summary: Dummy service manual start test
+kill-timeout: 2m
+
+execute: |
+    ${SUITE_DIR}/pebble_wrapper.sh stop dummy
+    ${SUITE_DIR}/pebble_wrapper.sh services | grep -E -e "dummy\s+enabled\s+inactive"
+    ${SUITE_DIR}/pebble_wrapper.sh changes | grep -e "Stop service \"dummy\""
+    ${SUITE_DIR}/pebble_wrapper.sh start dummy
+    ${SUITE_DIR}/pebble_wrapper.sh changes | grep -e "Start service \"dummy\""
+

--- a/spread-tests/unit/task/task.yaml
+++ b/spread-tests/unit/task/task.yaml
@@ -1,0 +1,17 @@
+
+summary: Pebble unit tests
+environment:
+    TARGET/cmd: ./cmd/pebble
+    TARGET/internal_daemon: ./internal/daemon
+    TARGET/internal_logger: ./internal/logger
+    TARGET/internal_osutil: ./internal/osutil
+    TARGET/internal_overlord: ./internal/overlord
+    TARGET/internal_plan: ./internal/plan
+    TARGET/internal_progress: ./internal/progress
+    TARGET/internal_servicelog: ./internal/servicelog
+    TARGET/internal_systemd: ./internal/systemd
+    TARGET/internal_testutil: ./internal/testutil
+    TARGET/internal_timeutil: ./internal/timeutil
+    TARGET/internal_timing: ./internal/timing
+execute: |
+    ./unit_test.sh $TARGET

--- a/spread-tests/unit/task/unit_test.sh
+++ b/spread-tests/unit/task/unit_test.sh
@@ -1,0 +1,8 @@
+#! /usr/bin/env bash
+
+set -e
+
+pushd ${SPREAD_PATH}
+    su ubuntu -s /bin/sh -c "go test $1"
+popd
+

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,0 +1,30 @@
+
+project: pebble
+
+environment:
+    SUITE_DIR: "${SPREAD_PATH}/${SPREAD_SUITE}."
+    TASK_DIR: "${SPREAD_PATH}/${SPREAD_TASK}"
+
+backends:
+    lxd:
+        systems: [ubuntu-22.04]
+
+        prepare: |
+            ${SPREAD_PATH}/spread-tests/install-go.sh
+
+suites:
+    spread-tests/integration/:
+        summary: Integration tests
+
+        prepare-each: |
+            ${SUITE_DIR}/start_pebble.sh
+
+        restore-each: |
+            ${SUITE_DIR}/stop_pebble.sh
+
+    spread-tests/unit/:
+        summary: Unit tests
+
+
+path: /pebble-spread-test
+

--- a/spread.yaml
+++ b/spread.yaml
@@ -10,7 +10,8 @@ backends:
         systems: [ubuntu-22.04]
 
         prepare: |
-            ${SPREAD_PATH}/spread-tests/install-go.sh
+            ${SPREAD_PATH}/spread-tests/install_go.sh
+            ${SPREAD_PATH}/spread-tests/install_gcc.sh
 
 suites:
     spread-tests/integration/:


### PR DESCRIPTION
This commit enables the use of spread to test pebble.

For now the only implemented spread backend is an LXD container.
The existing pebble unit tests are run in a spread test suite, as well
as two basic integration tests.
The pebble service is started and stopped for each individual
integration test.

To try it yourself, run spread from the root of this repo.

